### PR TITLE
fix: invalid escape sequence: \;

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -102,7 +102,7 @@ def _sonarqube_impl(ctx):
             #"for f in $(find $(dirname %s) -type l); do echo $f; done" % sq_properties_file.short_path,
             #"echo '... done.'",
             #
-            "find $(dirname %s) -type l -exec bash -c 'ln -f $(readlink $0) $0' {} \;" % sq_properties_file.short_path,
+            "find $(dirname %s) -type l -exec bash -c 'ln -f $(readlink $0) $0' {} \\;" % sq_properties_file.short_path,
             "exec %s -Dproject.settings=%s $@" % (ctx.executable.sonar_scanner.short_path, sq_properties_file.short_path),
         ]),
         is_executable = True,


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/8380