### PR TITLE
Update upstream for bazel 6.0.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Utilities to help analyse Bazel projects with SonarQube.
 
 [Example projects](./examples)
 
+## Version compatibility
+
+The SonarQubeCoverageGenerator utility is a direct copy of the equivalent lcov
+generator from Bazel upstream, and runs with Bazel's embedded
+`"@remote_coverage_tools//:all_lcov_merger_lib"` as a dependency. If using this
+to collect coverage info in SQ-compatible format, the version of this repository
+must be matched to the Bazel version being used.
+
+The list below includes the last compatible commit of this repository for
+specific Bazel versions, otherwise the latest should work with the latest Bazel.
+
+* Bazel < 6.0 - 37261de24f80b661bbc4726e3382ef43e9d66a6e
+
 ## Setup
 
 The included rules require some dependencies. In your WORKSPACE:

--- a/defs.bzl
+++ b/defs.bzl
@@ -103,7 +103,7 @@ def _sonarqube_impl(ctx):
             #"echo '... done.'",
             #
             "find $(dirname %s) -type l -exec bash -c 'ln -f $(readlink $0) $0' {} \\;" % sq_properties_file.short_path,
-            "exec %s -Dproject.settings=%s $@" % (ctx.executable.sonar_scanner.short_path, sq_properties_file.short_path),
+            "exec %s $@ -Dproject.settings=%s" % (ctx.executable.sonar_scanner.short_path, sq_properties_file.short_path),
         ]),
         is_executable = True,
     )

--- a/src/main/java/com/google/devtools/coverageoutputgenerator/SonarQubeCoverageGenerator.java
+++ b/src/main/java/com/google/devtools/coverageoutputgenerator/SonarQubeCoverageGenerator.java
@@ -1,9 +1,31 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.google.devtools.coverageoutputgenerator;
 
+import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_EXTENSION;
+import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_JSON_EXTENSION;
+import static com.google.devtools.coverageoutputgenerator.Constants.PROFDATA_EXTENSION;
+import static com.google.devtools.coverageoutputgenerator.Constants.TRACEFILE_EXTENSION;
+import static java.lang.Math.max;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -14,7 +36,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,17 +46,8 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.google.devtools.coverageoutputgenerator.Constants.CC_EXTENSIONS;
-import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_EXTENSION;
-import static com.google.devtools.coverageoutputgenerator.Constants.GCOV_JSON_EXTENSION;
-import static com.google.devtools.coverageoutputgenerator.Constants.PROFDATA_EXTENSION;
-import static com.google.devtools.coverageoutputgenerator.Constants.TRACEFILE_EXTENSION;
-import static java.lang.Math.max;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-
 /**
- * <p>A copy of {@link Main} (as of Bazel 4.0.0) which instead uses the
+ * <p>A copy of {@link Main} (as of Bazel 6.0.0) which instead uses the
  * {@link SonarQubeCoverageReportPrinter} to emit a SonarQube 'Generic Test
  * Coverage' XML format report.</p>
  * <p>This is located in the <code>com.google.devtools.coverageoutputgenerator</code>
@@ -70,7 +82,7 @@ public class SonarQubeCoverageGenerator {
         List<File> filesInCoverageDir =
                 flags.coverageDir() != null
                         ? getCoverageFilesInDir(flags.coverageDir())
-                        : Collections.emptyList();
+                        : ImmutableList.of();
         Coverage coverage =
                 Coverage.merge(
                         parseFiles(
@@ -145,12 +157,9 @@ public class SonarQubeCoverageGenerator {
         }
 
         if (flags.hasSourceFileManifest()) {
-            // The source file manifest is only required for C++ code coverage.
-            Set<String> ccSources = getCcSourcesFromSourceFileManifest(flags.sourceFileManifest());
-            if (!ccSources.isEmpty()) {
-                // Only filter out coverage if there were C++ sources found in the coverage manifest.
-                coverage = Coverage.getOnlyTheseCcSources(coverage, ccSources);
-            }
+            coverage =
+                    Coverage.getOnlyTheseSources(
+                            coverage, getSourcesFromSourceFileManifest(flags.sourceFileManifest()));
         }
 
         if (coverage.isEmpty()) {
@@ -193,13 +202,13 @@ public class SonarQubeCoverageGenerator {
      * <p>This method only returns the C++ source files, ignoring the other files as they are not
      * necessary when putting together the final coverage report.
      */
-    private static Set<String> getCcSourcesFromSourceFileManifest(String sourceFileManifest) {
+    private static Set<String> getSourcesFromSourceFileManifest(String sourceFileManifest) {
         Set<String> sourceFiles = new HashSet<>();
         try (FileInputStream inputStream = new FileInputStream(new File(sourceFileManifest));
              InputStreamReader inputStreamReader = new InputStreamReader(inputStream, UTF_8);
              BufferedReader reader = new BufferedReader(inputStreamReader)) {
             for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-                if (!isMetadataFile(line) && isCcFile(line)) {
+                if (!isMetadataFile(line)) {
                     sourceFiles.add(line);
                 }
             }
@@ -211,15 +220,6 @@ public class SonarQubeCoverageGenerator {
 
     private static boolean isMetadataFile(String filename) {
         return filename.endsWith(".gcno") || filename.endsWith(".em");
-    }
-
-    private static boolean isCcFile(String filename) {
-        for (String ccExtension : CC_EXTENSIONS) {
-            if (filename.endsWith(ccExtension)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static List<File> getGcovInfoFiles(List<File> filesInCoverageDir) {
@@ -302,7 +302,7 @@ public class SonarQubeCoverageGenerator {
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Error reading file " + file + ": " + e.getMessage());
         }
-        return mapBuilder.build();
+        return mapBuilder.buildOrThrow();
     }
 
     static Coverage parseFiles(List<File> files, Parser parser, int parallelism)
@@ -340,11 +340,11 @@ public class SonarQubeCoverageGenerator {
         int partitionSize = max(1, files.size() / parallelism);
         List<List<File>> partitions = Lists.partition(files, partitionSize);
         return pool.submit(
-                () ->
-                        partitions.parallelStream()
-                                .map((p) -> parseFilesSequentially(p, parser))
-                                .reduce((c1, c2) -> Coverage.merge(c1, c2))
-                                .orElse(Coverage.create()))
+                        () ->
+                                partitions.parallelStream()
+                                        .map((p) -> parseFilesSequentially(p, parser))
+                                        .reduce((c1, c2) -> Coverage.merge(c1, c2))
+                                        .orElse(Coverage.create()))
                 .get();
     }
 


### PR DESCRIPTION
Bring in 2 commits from after our fork point, to enable bazel 6.0 compatibility